### PR TITLE
fix(ci): fix dependabot-issue workflow permissions

### DIFF
--- a/.github/workflows/dependabot-issue.yml
+++ b/.github/workflows/dependabot-issue.yml
@@ -50,14 +50,5 @@ jobs:
 
             console.log(`Created tracking issue #${issue.number} for PR #${pr.number}`);
 
-            // Update PR body to reference the issue
-            const updatedBody = `${pr.body || ''}\n\n---\nCloses #${issue.number}`;
-
-            await github.rest.pulls.update({
-              owner,
-              repo,
-              pull_number: pr.number,
-              body: updatedBody
-            });
-
-            console.log(`Updated PR #${pr.number} to close issue #${issue.number}`);
+            // Note: We don't update the PR body because Dependabot PRs have
+            // restricted permissions. The issue references the PR instead.


### PR DESCRIPTION
## Summary

Fix the `dependabot-issue.yml` workflow that was failing with 'Resource not accessible by integration' error.

## Problem

Dependabot PRs run with restricted permissions. The workflow was trying to update the PR body to add 'Closes #X', but this fails because the token can't modify Dependabot-created PRs.

## Solution

Remove the PR body update step. The tracking issue will reference the PR instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)